### PR TITLE
[YUNIKORN-1122]Move constants to scheduler interface

### DIFF
--- a/lib/go/common/constants.go
+++ b/lib/go/common/constants.go
@@ -35,6 +35,7 @@ const (
 	ContainerImage = "si/container-image"
 	ContainerPorts = "si/container-ports"
 )
+
 // Constants for allocation tags
 const (
 	// Domains
@@ -53,5 +54,14 @@ const (
 	KeyAllowPreemption = "allowPreemption"
 
 	// Pods
-	CreationTime    = "creationTime"
+	CreationTime = "creationTime"
+)
+
+// Constants for Core and Shim
+const (
+	Memory                       = "memory"
+	CPU                          = "CPU"
+	AppTagNamespaceResourceQuota = "namespace.resourcequota"
+	AppTagStateAwareDisable      = "application.stateaware.disable"
+	NodeReadyAttribute           = "ready"
 )

--- a/lib/go/common/constants.go
+++ b/lib/go/common/constants.go
@@ -60,7 +60,7 @@ const (
 // Constants for Core and Shim
 const (
 	Memory                       = "memory"
-	CPU                          = "CPU"
+	CPU                          = "vcore"
 	AppTagNamespaceResourceQuota = "namespace.resourcequota"
 	AppTagStateAwareDisable      = "application.stateaware.disable"
 	NodeReadyAttribute           = "ready"


### PR DESCRIPTION
### What is this PR for?
move shim and core constants to si repo, after this PR merged, will update the shim and core with latest si repo.
Here is the list of shim and core:

- Memory = "memory" & CPU = "vcore"
core : `pkg/common/resources/resource.go`
shim: `pkg/constants/constants.go`
- NodeReadyAttribute = "ready"
core : `pkg/scheduler/objects/node.go`
shim: `pkg/constants/constants.go`
- AppTagNamespaceResourceQuota = "namespace.resourcequota"
core : `pkg/scheduler/objects/queue.go`
shim : `pkg/constants/constants.go`
- AppTagStateAwareDisable = "application.stateaware.disable"
core : `pkg/scheduler/objects/application.go`
shim : `pkg/constants/constants.go`


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1122

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
