### PR TITLE
[YUNIKORN-1297] move constants to md file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,10 @@ SI_PROTO := si.proto
 LIB_DIR := lib/go
 COMMON_LIB := $(LIB_DIR)/common
 CONSTANTS_GO := $(COMMON_LIB)/constants.go
+CONSTANTS_TMP := $(COMMON_LIB)/tmp_constants.go
 API_LIB := $(LIB_DIR)/api
 INTERFACE_GO := $(API_LIB)/interface.go
+INTERFACE_TMP := $(API_LIB)/tmp_interface.go
 
 define GENERATED_HEADER
 // Licensed to the Apache Software Foundation (ASF) under one
@@ -91,23 +93,25 @@ $(SI_PROTO).tmp: $(SI_SPEC)
 	(diff $@ $(SI_PROTO) > /dev/null 2>&1 || mv -f $@ $(SI_PROTO)) && \
 		rm -f $@
 
-$(CONSTANTS_GO).tmp: $(SI_SPEC)
+$(CONSTANTS_TMP): $(SI_SPEC)
 	test -d $(COMMON_LIB) || mkdir -p $(COMMON_LIB)
 	@echo "$$GENERATED_HEADER" > $@
 	@echo "$$PACKAGE_DEF" >> $@
-	cat $< | sed -n -e '/``constants$$/,/^```$$/ p' | sed '/^```/d' >> $@
+	cat $< | sed -n -e '/```constants$$/,/^```$$/ p' | sed '/^```/ s/.*//g' >> $@
+	go fmt $@
 	(diff $@ $(CONSTANTS_GO) > /dev/null 2>&1 || mv -f $@ $(CONSTANTS_GO)) && \
 		rm -f $@
 
-$(INTERFACE_GO).tmp: $(SI_SPEC)
+$(INTERFACE_TMP): $(SI_SPEC)
 	test -d $(API_LIB) || mkdir -p $(API_LIB)
 	@echo "$$GENERATED_HEADER" > $@
-	cat $< | sed -n -e '/``golang$$/,/^```$$/ p' | sed '/^```/d' >> $@
+	cat $< | sed -n -e '/``golang$$/,/^```$$/ p' | sed '/^```/ s/.*//g' >> $@
+	go fmt $@
 	(diff $@ $(INTERFACE_GO) > /dev/null 2>&1 || mv -f $@ $(INTERFACE_GO)) && \
 		rm -f $@
 
 # Build the go language bindings from the spec via a generated proto
-build: $(SI_PROTO).tmp $(CONSTANTS_GO).tmp $(INTERFACE_GO).tmp 
+build: $(SI_PROTO).tmp $(CONSTANTS_TMP) $(INTERFACE_TMP)
 	$(MAKE) -C $(LIB_DIR)
 
 # Set a empty recipe

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ $(CONSTANTS_TMP): $(SI_SPEC)
 $(INTERFACE_TMP): $(SI_SPEC)
 	test -d $(API_LIB) || mkdir -p $(API_LIB)
 	@echo "$$GENERATED_HEADER" > $@
-	cat $< | sed -n -e '/``golang$$/,/^```$$/ p' | sed '/^```/ s/.*//g' >> $@
+	cat $< | sed -n -e '/```golang$$/,/^```$$/ p' | sed '/^```/ s/.*//g' >> $@
 	go fmt $@
 	(diff $@ $(INTERFACE_GO) > /dev/null 2>&1 || mv -f $@ $(INTERFACE_GO)) && \
 		rm -f $@

--- a/lib/go/si/si.pb.go
+++ b/lib/go/si/si.pb.go
@@ -172,6 +172,7 @@ func (EventRecord_Type) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_si_09b58b0848c8fa12, []int{29, 0}
 }
 
+//
 // service MetricsService {
 // }
 type RegisterResourceManagerRequest struct {

--- a/scheduler-interface-spec.md
+++ b/scheduler-interface-spec.md
@@ -715,6 +715,19 @@ const (
 )
 ```
 
+Miscellaneous constants for resources and other values.
+
+```constants
+// Constants for Core and Shim
+const (
+	Memory                       = "memory"
+	CPU                          = "vcore"
+	AppTagNamespaceResourceQuota = "namespace.resourcequota"
+	AppTagStateAwareDisable      = "application.stateaware.disable"
+	NodeReadyAttribute           = "ready"
+)
+```
+
 ### Scheduler plugin
 
 SchedulerPlugin is a way to extend scheduler capabilities. Scheduler shim can implement such plugin and register itself to


### PR DESCRIPTION
### What is this PR for?
The md file is the source of truth moving the constants to the md file
and run a make to re-generate the go file.
Run go fmt over the file to make sure it is properly formatted.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1297

### How should this be tested?
Follow up jira is logged to change the build process and fail the process if this happens again