### PR TITLE
[YUNIKORN-1298] add check for generated file changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: 
       - master
-  push:
-    branches:
-      - master
 
 jobs:
   build:
@@ -16,10 +13,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Check license
         run: make license-check
-        if: ${{ github.event_name == 'pull_request' }}
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version-file: .go_version
-      - name: Run build
-        run: make 
+      - name: Build and Check for changes
+        run: make check

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,20 @@ build: $(SI_PROTO).tmp $(CONSTANTS_TMP) $(INTERFACE_TMP)
 test:
 	@echo ""
 
+# Check that the updates are made in the source file: scheduler-interface.md
+# The check is run as part of the pre-commit and a build should not update any files.
+.PHONY: check
+check: build
+	@echo "Check for changes by build"
+	@if ! git diff --quiet; then \
+		echo "'make build' updated the following files:\n" ; \
+		git status --untracked-files=no --porcelain ; \
+		echo "\nUpdates must be made in scheduler-interface.md" ; \
+		echo "Run 'make build' before committing PR changes" ; \
+		exit 1; \
+	fi
+	@echo "  all OK"
+
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 # Check for missing license headers
 .PHONY: license-check


### PR DESCRIPTION
### What is this PR for?
The pre-commit build for a PR must fail if any of the generated files
are changed when a simple `make build` is run.
Remove build on push as it does nothing.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1298

### How should this be tested?
The pre-commit build should never fail for any change to be committed.
