### PR TITLE
[YUNIKORN-1954] remove KeyAllowPreemption

### DIFF
--- a/lib/go/common/constants.go
+++ b/lib/go/common/constants.go
@@ -48,10 +48,9 @@ const (
 	GroupAnnotation = "annotation/"
 
 	// Keys
-	KeyPodName         = "podName"
-	KeyNamespace       = "namespace"
-	KeyRequiredNode    = "requiredNode"
-	KeyAllowPreemption = "allowPreemption"
+	KeyPodName      = "podName"
+	KeyNamespace    = "namespace"
+	KeyRequiredNode = "requiredNode"
 
 	// Pods
 	CreationTime = "creationTime"

--- a/scheduler-interface-spec.md
+++ b/scheduler-interface-spec.md
@@ -744,7 +744,6 @@ const (
 	KeyPodName         = "podName"
 	KeyNamespace       = "namespace"
 	KeyRequiredNode    = "requiredNode"
-	KeyAllowPreemption = "allowPreemption"
 
 	// Pods
 	CreationTime    = "creationTime"


### PR DESCRIPTION
### What is this PR for?

We removed `KeyAllowPreemption` in [yunikorn-core#511](https://github.com/apache/yunikorn-core/pull/511/files#diff-ae0924b6062288f1f5c143aa68804181c8a72bc2e2d5af068bc630a103ecc7c8), so we can also remove it from scheduler-interface.


### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1954
