### PR TITLE
[YUNIKORN-2300] Fix typo in scheduler-interface: typo in comment to describe tags

### DIFF
--- a/lib/go/si/si.pb.go
+++ b/lib/go/si/si.pb.go
@@ -1631,8 +1631,8 @@ type AddApplicationRequest struct {
 	PartitionName string `protobuf:"bytes,3,opt,name=partitionName,proto3" json:"partitionName,omitempty"`
 	// The user group information of the application owner
 	Ugi *UserGroupInformation `protobuf:"bytes,4,opt,name=ugi,proto3" json:"ugi,omitempty"`
-	// A set of tags for the application. These tags provide application level generic inforamtion.
-	// The tags are optional and are used in placing an appliction or scheduling.
+	// A set of tags for the application. These tags provide application level generic information.
+	// The tags are optional and are used in placing an application or scheduling.
 	// Application tags are not considered when processing AllocationAsks.
 	Tags map[string]string `protobuf:"bytes,5,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Execution timeout: How long this application can be in a running state

--- a/scheduler-interface-spec.md
+++ b/scheduler-interface-spec.md
@@ -475,8 +475,8 @@ message AddApplicationRequest {
   string partitionName = 3;
   // The user group information of the application owner
   UserGroupInformation ugi = 4;
-  // A set of tags for the application. These tags provide application level generic inforamtion.
-  // The tags are optional and are used in placing an appliction or scheduling.
+  // A set of tags for the application. These tags provide application level generic information.
+  // The tags are optional and are used in placing an application or scheduling.
   // Application tags are not considered when processing AllocationAsks.
   map<string, string> tags = 5;
   // Execution timeout: How long this application can be in a running state

--- a/si.proto
+++ b/si.proto
@@ -239,8 +239,8 @@ message AddApplicationRequest {
   string partitionName = 3;
   // The user group information of the application owner
   UserGroupInformation ugi = 4;
-  // A set of tags for the application. These tags provide application level generic inforamtion.
-  // The tags are optional and are used in placing an appliction or scheduling.
+  // A set of tags for the application. These tags provide application level generic information.
+  // The tags are optional and are used in placing an application or scheduling.
   // Application tags are not considered when processing AllocationAsks.
   map<string, string> tags = 5;
   // Execution timeout: How long this application can be in a running state


### PR DESCRIPTION
### What is this PR for?
Fix typo in scheduler-interface. Specifically, typo in comment to describe tags
https://issues.apache.org/jira/browse/YUNIKORN-2300 

### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2300 

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
