### PR TITLE
[YUNIKORN-2340] Upgrade actions versions in Github Action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: .go_version
       - name: Check license


### PR DESCRIPTION
### What is this PR for?
Bump below actions verions to surpress the "Node.js 16 actions are deprecated." warning message:

1. actions/checkout (v3 -> v4)
2. actions/setup-go (v3 -> v5)   ([Only support node js 20 in v5](https://github.com/actions/setup-go/releases))


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Update below repo's actions version:
1. yunikorn-k8shim
2. yunikorn-core

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2340

### How should this be tested?
Tested in Github action.  Create a pull request to master branch and check the Actions result.
ex: https://github.com/chenyulin0719/yunikorn-scheduler-interface/actions/runs/7693552027


### Screenshots (if appropriate)
After:
<img width="1439" alt="image" src="https://github.com/apache/yunikorn-scheduler-interface/assets/26764036/0ba039ee-3aa4-4fe6-a827-48af0866be92">

Before:
<img width="1459" alt="image" src="https://github.com/apache/yunikorn-scheduler-interface/assets/26764036/9a1a4745-002a-41ba-981c-2c0cb8a9a238">


### Questions:
NA