### PR TITLE
[YUNIKORN-2416] Cleanup replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,17 +28,10 @@ require (
 
 require (
 	github.com/golang/protobuf v1.5.3 // indirect
-	golang.org/x/net v0.20.0 // indirect
-	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/net v0.12.0 // indirect
+	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 )
 
-replace (
-	golang.org/x/crypto => golang.org/x/crypto v0.18.0
-	golang.org/x/lint => golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
-	golang.org/x/net => golang.org/x/net v0.20.0
-	golang.org/x/sys => golang.org/x/sys v0.16.0
-	golang.org/x/text => golang.org/x/text v0.14.0
-	golang.org/x/tools => golang.org/x/tools v0.17.0
-)
+replace golang.org/x/net => golang.org/x/net v0.21.0 // CVE in indirect version v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
-golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
-golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
-golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
### What is this PR for?
Cleanup unnecessarily golang.org/x/ modules in replace directives. Those replace modules were introduced in 
- [YUNIKORN-1449 Fix CVE issues detected in golang.org/x/ modules](https://issues.apache.org/jira/browse/YUNIKORN-1449)

However, in the lastest mod.go, only golang.org/x/net have CVE issue.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Update below project's go.mod in order:
1. yunikorn-core (To be merged changes in my forked repo: [Link](https://github.com/apache/yunikorn-core/compare/master...chenyulin0719:yunikorn-core:YUNIKORN-2416))
2. yunikorn-shim (To be merged changes in my forked repo: [Link](https://github.com/apache/yunikorn-k8shim/compare/master...chenyulin0719:yunikorn-k8shim:YUNIKORN-2416))
3. yunikorn-release (To be merged changes in my forked repo: [Link](https://github.com/apache/yunikorn-release/compare/master...chenyulin0719:yunikorn-release:YUNIKORN-2416))

Replace directives to my forked repo will be removed once the upstream PR merged.

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2416

### How should this be tested?

1. Run CVE check (or use your IDE's vulnerability analysis tool).
2. Run E2E test with this new dependencis

E2E test passed in my forked repo:
- https://github.com/chenyulin0719/yunikorn-k8shim/actions/runs/8001145180

### Screenshots (if appropriate)

CVE check pass in GOLAND IDE:
<img width="1462" alt="image" src="https://github.com/apache/yunikorn-scheduler-interface/assets/26764036/36f98ee0-c757-470a-83b9-f7097801114c">


CVE check pass with govulncheck:
<img width="797" alt="image" src="https://github.com/apache/yunikorn-scheduler-interface/assets/26764036/79624df9-6552-42ca-971e-5fd09ed1f3e5">


### Questions:
NA
