### PR TITLE
[YUNIKORN-2502] Add YuniKorn internal domain name to yunikorn-scheduler-interface

### DIFF
--- a/lib/go/common/constants.go
+++ b/lib/go/common/constants.go
@@ -39,8 +39,9 @@ const (
 // Constants for allocation tags
 const (
 	// Domains
-	DomainK8s      = "kubernetes.io/"
-	DomainYuniKorn = "yunikorn.apache.org/"
+	DomainK8s              = "kubernetes.io/"
+	DomainYuniKorn         = "yunikorn.apache.org/"
+	DomainYuniKornInternal = "internal.yunikorn.apache.org/"
 
 	// Groups
 	GroupMeta       = "meta/"

--- a/scheduler-interface-spec.md
+++ b/scheduler-interface-spec.md
@@ -744,8 +744,9 @@ Example allocation key: `kubernetes.io/meta/namespace`.
 // Constants for allocation tags
 const (
 	// Domains
-	DomainK8s      = "kubernetes.io/"
-	DomainYuniKorn = "yunikorn.apache.org/"
+	DomainK8s              = "kubernetes.io/"
+	DomainYuniKorn         = "yunikorn.apache.org/"
+	DomainYuniKornInternal = "internal.yunikorn.apache.org/"
 
 	// Groups
 	GroupMeta       = "meta/"


### PR DESCRIPTION
### What is this PR for?
Add YuniKorn internal domain constant.
- DomainYuniKornInternal = "internal.yunikorn.apache.org/"

### What type of PR is it?
* [x] - Feature

### Todos
- Update Shim/Core dependencies

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2502

### How should this be tested?
NA

### Screenshots (if appropriate)
NA

