### PR TITLE
[YUNIKORN-2541] Sync golang.org/x/crypto version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 )
 
 replace (
-	golang.org/x/crypto => golang.org/x/crypto v0.19.0
+	golang.org/x/crypto => golang.org/x/crypto v0.21.0
 	golang.org/x/net => golang.org/x/net v0.23.0
 	golang.org/x/sys => golang.org/x/sys v0.18.0
 	golang.org/x/text => golang.org/x/text v0.14.0


### PR DESCRIPTION
### What is this PR for?
After k8shim updated golang.org/x/net module (https://github.com/apache/yunikorn-k8shim/pull/822), the golang.org/x/crypto module is automatically updated by `go mod tidy`.
Therefore, this PR updates it to ensure that the versions of all three project are consistent.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - core and k8shim should be updated also.

### What is the Jira issue?
[YUNIKORN-2541](https://issues.apache.org/jira/browse/YUNIKORN-2541/)

### How should this be tested?

### Screenshots (if appropriate)
N/A

### Questions:
N/A
